### PR TITLE
removed overflow-x property from .ladder-container to fix an issue with the carousel in the app.

### DIFF
--- a/assets/styles/ladder.css
+++ b/assets/styles/ladder.css
@@ -8,7 +8,6 @@
   grid
   justify-start
   items-start
-  overflow-x-scroll
   pb-4
   ;
 }


### PR DESCRIPTION
## Summary
- removed overflow-x property from .ladder-container to fix an issue with the carousel in the app.
- checked the prototype but it doesn't affect it.