### PR TITLE
added freshdesk overrides for widget width.

### DIFF
--- a/assets/styles/freshdesk.css
+++ b/assets/styles/freshdesk.css
@@ -1,0 +1,6 @@
+/* Overriding Freshdesk's button width */
+
+#launcher-frame {
+  min-width: 87px !important;
+  max-width: 87px !important;
+}

--- a/assets/styles/globals.css
+++ b/assets/styles/globals.css
@@ -1,6 +1,8 @@
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 
+@import "./freshdesk.css";
+
 @import "./animation";
 @import "./colors";
 @import "./fonts";


### PR DESCRIPTION
There's no way to override freshdesk things from the freshdesk client. the only way is to use !important in more specific CSS. 